### PR TITLE
fix: focus-chat 视图兼容——识别 [data-focus-flow] 助手行结构 (fix #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-d
 - **Reply chips**: after streaming settles (`data-streaming` removed), each `Annotation N:` is replaced with a hoverable chip; item data is stored on the most recent user message carrying the annotation tag (`tag.__annotationItems`) and rebuilt after refresh; **snapshot the text nodes collected by the TreeWalker before touching the DOM, then replace one by one** — replacing a child mid-walk invalidates the walker pointer and only the first node gets processed
 - **IME-safe**: the Enter interception carries `isComposing` / keyCode 229 guards; never hard-edits the composer textarea's DOM; `setDraft` only assembles the annotation block at the last moment before submit and never clobbers the user's draft
 - **No reliance on send-completion event chains**: bubble decoration uses MutationObserver + polling (`watchInputDraft` can be ineffective before the session is loaded at init; it is only a staging entry)
+- **Focus-chat compatible**: works inside the focus conversation view of [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) — assistant rows there are `[data-focus-flow]` containers with a `*_assistant` CSS-Modules class (plus `data-streaming` while running); selection, annotation, reply chips, and re-anchoring all work in the focus tab alongside the main chat view
 
 ## Version history
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,7 @@ curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-d
 - **回复芯片**：回复流式结束后（`data-streaming` 移除），把「Annotation N：」替换为可悬浮芯片；条目数据存于最近一条带批注标签的用户消息上（`tag.__annotationItems`），刷新后自动重建；**改 DOM 前先快照 TreeWalker 收集的文本节点再逐个替换**（遍历中途 replaceChild 会让 walker 指针失效，只处理到第一个节点）
 - **IME 安全**：Enter 拦截带 `isComposing`/keyCode 229 守卫；不 DOM 硬改 composer textarea；`setDraft` 仅在提交前一刻拼批注块，不覆盖用户草稿
 - **不依赖发送完成事件链**：气泡装饰走 MutationObserver + 轮询（`watchInputDraft` 在初始化时会话未加载时会失效，仅作暂存入口）
+- **聚焦对话兼容**：支持 [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) 的聚焦会话视图——其助手行是 `[data-focus-flow]` 内 class 含 `*_assistant`（CSS Modules 哈希名）的容器（流式期间行带 `data-streaming`）；选区批注、回复芯片、角标重新定位在聚焦 tab 与主视图一样可用
 
 ## 版本历史
 

--- a/client.js
+++ b/client.js
@@ -30,6 +30,11 @@
 //
 // 判别式与 omdsh-dev/navbar 一致：助手行 = [data-time-hover-root] 且不含
 // user bubble（[class*="bubble"]）。
+// focus-chat（@dingyi222666/dsh-focus-chat）兼容：其会话视图挂载在
+// [data-focus-flow] 内，助手行 = class 含 "assistant" 的容器（CSS Modules
+// 哈希名形如 `<hash>_assistant`，流式期间行自带 data-streaming），用户行
+// 沿用 data-time-hover-root；切换视图 tab 时主视图会卸载，故行判别必须
+// 同时覆盖两种视图结构（见 assistantRows / allMessageRows / assistantRowOf）。
 window.__ModuleLoader__.load({
   // 必须与 package.json "name" 完全一致，否则 client-modules 报：
   // bundle loaded without registering "@omdsh-dev/dsh-annotation"
@@ -161,6 +166,46 @@ window.__ModuleLoader__.load({
         && !el.hasAttribute('data-turn-tail')
     }
 
+    // ---------- focus-chat（@dingyi222666/dsh-focus-chat）视图兼容 ----------
+    // 该插件在 conversation.view 槽注册「聚焦会话」视图：挂载于
+    // [data-focus-flow]（列容器）→ [data-focus-anchor-key]（行包装）→ 行。
+    // 助手行 = class 含 "assistant" 的容器（CSS Modules 哈希名保留 local 名，
+    // 形如 `<hash>_assistant`；流式期间行自带 data-streaming，停流后移除）。
+    // 用户行保留 data-time-hover-root + [class*="bubble"]，与旧判别式一致。
+    function isFocusFlow(el) {
+      return el !== null && typeof el.closest === 'function'
+        && el.closest('[data-focus-flow]') !== null
+    }
+
+    function isFocusAssistantRow(el) {
+      if (el === null || !el.classList || !isFocusFlow(el)) return false
+      for (var i = 0; i < el.classList.length; i++) {
+        if (el.classList[i].indexOf('assistant') !== -1) return true
+      }
+      return false
+    }
+
+    /** focus 视图的全部消息行（用户 + 助手，DOM 顺序）。只保留最外层助手
+     *  容器（markdown 内部子元素也可能带含 assistant 的类名）。 */
+    function focusMessageRows() {
+      var flow = document.querySelector('[data-focus-flow]')
+      if (flow === null) return []
+      var out = []
+      var all = flow.querySelectorAll('[data-time-hover-root], [class*="assistant"]')
+      for (var i = 0; i < all.length; i++) {
+        var el = all[i]
+        if (el.hasAttribute('data-time-hover-root')) {
+          if (!isAssistantRow(el)) out.push(el)
+          continue
+        }
+        if (!isFocusAssistantRow(el)) continue
+        var p = el.parentElement
+        if (p !== null && p !== flow && isFocusAssistantRow(p)) continue
+        out.push(el)
+      }
+      return out
+    }
+
     function assistantRowOf(node) {
       var el = (node instanceof Element) ? node : (node !== null ? node.parentElement : null)
       while (el !== null && el !== document.body) {
@@ -170,6 +215,14 @@ window.__ModuleLoader__.load({
         if (el.hasAttribute('data-time-hover-root')) {
           return isAssistantRow(el) ? el : null
         }
+        if (isFocusAssistantRow(el)) {
+          // 冒到最外层 focus 助手容器（内部子元素可能也含 assistant 类名）。
+          while (el.parentElement !== null && el.parentElement !== document.body
+            && isFocusAssistantRow(el.parentElement)) {
+            el = el.parentElement
+          }
+          return el
+        }
         el = el.parentElement
       }
       return null
@@ -178,15 +231,21 @@ window.__ModuleLoader__.load({
     function assistantRows() {
       var modern = document.querySelectorAll('[data-chat-flow-kind="assistant-step"]')
       if (modern.length > 0) return Array.prototype.slice.call(modern)
+      var focus = focusMessageRows().filter(isFocusAssistantRow)
+      if (focus.length > 0) return focus
       return Array.prototype.slice.call(document.querySelectorAll('[data-time-hover-root]'))
         .filter(isAssistantRow)
     }
 
     /** 全部消息行（用户 + 助手 + 其它节点）：新版走 data-chat-flow-kind，
-     *  旧版回退 data-time-hover-root。用于气泡装饰、批注条目回溯。 */
+     *  旧版回退 data-time-hover-root；focus-chat 视图单独按 DOM 顺序收集
+     *  （会话视图 tab 切换时主视图会卸载，两种结构不同时存在）。
+     *  用于气泡装饰、批注条目回溯。 */
     function allMessageRows() {
       var modern = document.querySelectorAll('[data-chat-flow-kind]')
       if (modern.length > 0) return Array.prototype.slice.call(modern)
+      var focus = focusMessageRows()
+      if (focus.length > 0) return focus
       return Array.prototype.slice.call(document.querySelectorAll('[data-time-hover-root]'))
     }
 
@@ -404,6 +463,10 @@ window.__ModuleLoader__.load({
       if (saved !== undefined && saved !== null && saved.seqKey !== '') {
         try {
           var item = document.querySelector('[data-chat-anchor-key="' + saved.seqKey + '"]')
+          // focus-chat 视图的锚 key 属性名不同，值语义一致。
+          if (item === null) {
+            item = document.querySelector('[data-focus-anchor-key="' + saved.seqKey + '"]')
+          }
           if (item !== null) {
             var itText = item.textContent || ''
             if (saved.textOffset >= 0) {
@@ -508,6 +571,7 @@ window.__ModuleLoader__.load({
       }
       if (best !== null && (ctx === null || bestScore > 0)) return best
       var flow = document.querySelector('[data-chat-flow]')
+      if (flow === null) flow = document.querySelector('[data-focus-flow]')
       if (flow !== null) {
         var full2 = flow.textContent || ''
         var positions2 = allPositionsOf(flow, quote)
@@ -1040,11 +1104,17 @@ window.__ModuleLoader__.load({
           }
           var node = live.commonAncestorContainer
           var el = node instanceof Element ? node : (node !== null ? node.parentElement : null)
-          while (el !== null && el !== document.body && !el.hasAttribute('data-chat-anchor-key')) {
+          // 主视图锚 key 为 data-chat-anchor-key；focus-chat 视图为
+          // data-focus-anchor-key，两者等价（消息 seq 锚定）。
+          while (el !== null && el !== document.body
+            && !el.hasAttribute('data-chat-anchor-key')
+            && !el.hasAttribute('data-focus-anchor-key')) {
             el = el.parentElement
           }
-          if (el !== null && el.hasAttribute('data-chat-anchor-key')) {
-            anchor.seqKey = el.getAttribute('data-chat-anchor-key') || ''
+          if (el !== null
+            && (el.hasAttribute('data-chat-anchor-key') || el.hasAttribute('data-focus-anchor-key'))) {
+            anchor.seqKey = el.getAttribute('data-chat-anchor-key')
+              || el.getAttribute('data-focus-anchor-key') || ''
             if (textMatch) {
               var itemText = el.textContent || ''
               var realOff = offsetOfRangeInRow(el, live)
@@ -1520,7 +1590,7 @@ window.__ModuleLoader__.load({
         var rows = assistantRows()
         for (var i = 0; i < rows.length; i++) {
           var el = rows[i]
-          if (!isAssistantRow(el)) continue
+          if (!isAssistantRow(el) && !isFocusAssistantRow(el)) continue
           // 新版 data-streaming 标记在 AssistantMarkdown 内部元素上（行元素
           // 本身没有）——必须查行内，否则流式输出途中就把「Annotation N：」
           // 替换成芯片，与 React 正在更新的文本节点冲突，整条回复可能渲染

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omdsh-dev/dsh-annotation",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "type": "module",
   "description": "DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the annotation block with your message — the model replies to each annotation by number, with hoverable chips in the reply.",
   "main": "index.mjs",


### PR DESCRIPTION
## 背景

Closes #3：当用户使用 [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat)（聚焦会话视图）时，批注只会在原 tab 生效。原因：focus-chat 在 `conversation.view` 槽注册独立视图，**切换 tab 时主视图会卸载**（`renderSlot(..., { only: active.id })`）；其助手行结构是 `[data-focus-flow]` 内 class 含 `assistant` 的容器（CSS Modules 哈希名如 `<hash>_assistant`，流式期间行自带 `data-streaming`），既没有 `data-chat-flow-kind` 也没有 `data-time-hover-root`，因此 `assistantRowOf()` 走不到任何助手行，选区工具条、批注、回复芯片全部失效。

## 改动（client.js）

- **行判别**：新增 `isFocusFlow` / `isFocusAssistantRow` / `focusMessageRows`，`assistantRowOf()` 冒泡时识别 focus 助手行（并冒到最外层容器）；`assistantRows()` / `allMessageRows()` 在无主视图行时按 DOM 顺序收集 focus 用户行 + 助手行
- **锚定**：`captureAnchor()` 兼容 `data-focus-anchor-key`；`locateQuote()` 的 seqKey 与全流回退同时查询 `[data-focus-anchor-key]` / `[data-focus-flow]`
- **回复芯片**：`decorateAssistantAnnotations()` 接受 focus 助手行（`isFocusAssistantRow`），流式守卫沿用行上 `data-streaming`
- 版本 1.3.14；README 双语补兼容说明

## 验证

- 新增本地冒烟 `scripts/smoke-focus.mjs`（仓库惯例 scripts/ 不入库）：桩掉 ModuleLoader/服务、手工构造 focus 视图 DOM，13 项断言全绿——选区工具条、用户行不弹工具条、保存批注高亮+角标、气泡隐藏批注块+贴标签、回复「Annotation N」芯片、流式行不装饰、DOM 重渲染后按 seqKey 重新定位角标、主视图 `data-chat-flow-kind` 回归
- 既有 `smoke-v1.mjs` 真实 GUI E2E（新会话→批注→发送→回复芯片）全绿，无控制台错误