### PR TITLE
fix: don't clear collected annotations on plain draft clears

### DIFF
--- a/client.js
+++ b/client.js
@@ -1187,6 +1187,7 @@ window.__ModuleLoader__.load({
           if (draft.indexOf('我批注了以下') !== -1) return
           var block = buildBlock()
           shell.setDraft(block + '\n' + draft)
+          annotationAttached = true
           console.log('[annotation] 批注块已拼入草稿，回车将随消息发送（' + ui.quotes.length + ' 条）')
         } catch (err) {
           console.warn('[annotation] 批注拼稿失败：', err)
@@ -1378,6 +1379,9 @@ window.__ModuleLoader__.load({
 
       // ---------- 发送完成监听（草稿从有内容变空 → 清空批注集） ----------
       var inputUnsub = null
+      // 仅当批注块真正拼入过草稿（用户按过回车）才在草稿清空时清除批注，
+      // 避免普通草稿编辑（打字后删字）误触发「已发送」判定而清空批注集。
+      var annotationAttached = false
       function watchInputDraft() {
         if (typeof inputUnsub === 'function') { inputUnsub(); inputUnsub = null }
         var id = sessions.list.getSnapshot().current
@@ -1394,11 +1398,12 @@ window.__ModuleLoader__.load({
             if (ui.quotes.length === 0) return
             // 发送完成：草稿从有内容变空 → 脚标消失、编号下次从 1 开始；
             // 同时在刚发出的用户消息气泡上贴「N 条批注」标签。
-            if (wasHad && d === '') {
+            if (wasHad && d === '' && annotationAttached) {
               var sentItems = ui.quotes.map(function (q) {
                 return { text: q.text, note: q.note || '' }
               })
               ui.quotes = []
+              annotationAttached = false
               tipLayer.textContent = ''
               updateChip()
               renderMarkers()
@@ -1752,6 +1757,7 @@ window.__ModuleLoader__.load({
         lastSessionId = cur
         if (ui.mode !== 'closed') closeToolbar()
         ui.quotes = []
+        annotationAttached = false
         ui.noteDraft = ''
         tipLayer.textContent = ''
         updateChip()


### PR DESCRIPTION
## Problem

Collected annotations are silently cleared when the composer draft goes non-empty → empty **without sending**. Reproduce: select text → save an annotation → type in the composer → delete the typed text → the annotation is gone (chip disappears, `ui.quotes` wiped), even though nothing was sent.

## Root cause

`watchInputDraft()` subscribes to the composer input state and treats any draft `has-content → empty` transition as a proxy for "message sent", wiping `ui.quotes`:

```js
if (wasHad && d === '') {
  ...
  ui.quotes = []
}
```

That transition is not send-specific: the user deleting their typed text produces the identical signal, so annotations collected before typing are destroyed by the very act of editing the draft.

## Fix

Track whether the annotation block was actually injected into the draft by `attachAndSend()` (a module-level `annotationAttached` flag):

- `attachAndSend()` sets the flag after `setDraft(block + '\n' + draft)` — i.e. only when the user really pressed Enter with annotations collected;
- `watchInputDraft()` only clears quotes when the flag is set, and resets it after the clear;
- the flag is also reset on session switch.

The send-grounded fallback already present in `decorateAll()` (clearing when the sent bubble carrying the annotation block appears in the DOM) is untouched and still works as the reliable clearing path after a real send.

## Verification

- Bug path: annotate → type → delete all text → annotation persists ✅
- Normal path: annotate → Enter → annotation block attached to the message, numbering resets ✅
- Long annotation content ✅ · multiple annotations in one message (numbered 1..N) ✅ · annotations on earlier messages ✅
- Tested on macOS, dsh `0.1.0-rc.6`, web profile; same patch verified on a remote server with the same version.
