### PR TITLE
fix: 发布规范合规——补 types/src/tsconfig/build 入口与 files/peer (#7)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,0 @@
-// dsh-annotation 的 Node half：浏览器端插件，Node 侧为空实现。
-// 真实功能在 client.js（浏览器 bundle），经 dshClient 声明接入 dsh web。
-export default {
-  name: 'dsh-annotation',
-  apply() {},
-}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,6 @@
+// dsh-annotation 的 Node half：浏览器端插件，Node 侧为空实现。
+// 真实功能在 client.js（浏览器 bundle），经 dsh.client 声明接入 dsh web。
+// 这里是干净构建入口 src/index.ts → lib/index.js（tsc，零运行时依赖）。
+export const name = 'dsh-annotation';
+export function apply() { }
+export default { name, apply };

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,0 +1,7 @@
+export declare const name = "dsh-annotation";
+export declare function apply(): void;
+declare const _default: {
+    name: string;
+    apply: typeof apply;
+};
+export default _default;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
   "name": "@omdsh-dev/dsh-annotation",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "type": "module",
   "description": "DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the annotation block with your message — the model replies to each annotation by number, with hoverable chips in the reply.",
-  "main": "index.mjs",
+  "main": "lib/index.js",
+  "types": "lib/types/index.d.ts",
   "exports": {
-    ".": "./index.mjs",
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/index.js"
+    },
     "./client": "./client.js",
     "./package.json": "./package.json"
   },
   "files": [
-    "index.mjs",
+    "lib",
+    "src",
+    "tsconfig.json",
     "client.js",
     "cordis.patch.yml",
     "README.md",
@@ -18,8 +24,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "check": "node --check index.mjs && node --check client.js",
-    "prepublishOnly": "npm run check"
+    "build": "node -e \"require('node:fs').rmSync('lib', { recursive: true, force: true })\" && tsc -p tsconfig.json",
+    "check": "npm run build && node --check lib/index.js && node --check client.js",
+    "prepack": "npm run check"
   },
   "publishConfig": {
     "access": "public"
@@ -27,6 +34,12 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/omdsh-dev/dsh-annotation.git"
+  },
+  "peerDependencies": {
+    "cordis": "^4.0.0-rc.7 || ^4.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.0"
   },
   "dsh": {
     "bundle": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+// dsh-annotation 的 Node half：浏览器端插件，Node 侧为空实现。
+// 真实功能在 client.js（浏览器 bundle），经 dsh.client 声明接入 dsh web。
+// 这里是干净构建入口 src/index.ts → lib/index.js（tsc，零运行时依赖）。
+
+export const name = 'dsh-annotation'
+
+export function apply(): void {}
+
+export default { name, apply }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "declarationDir": "lib/types",
+    "outDir": "lib",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "noEmitOnError": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Addresses issue #7（发布规范：缺 types/src/tsconfig/build 入口）:

- **`types`**: 新增 `lib/types/index.d.ts`，`package.json` 声明 `types` 且 `exports["."]` 带 types 条件
- **`src`/`tsconfig`/build**: 新增 `src/index.ts`（Node half 空实现，语义与原 `index.mjs` 一致）+ `tsconfig.json`（NodeNext、declaration、outDir `lib`）+ 跨平台 `scripts.build`
- **构建入口**: `scripts.prepack` 发布前重建并校验；同时提交 `lib/` 产物，Git 安装/clean checkout 均有入口
- **`files`**: 补 `lib`、`src`、`tsconfig.json`（`cordis.patch.yml` 原本已包含）
- **`peerDependencies`**: 声明 `cordis`
- 版本号 → `1.3.16`

## Verification

- `npm run check` 通过（tsc build + `node --check` lib/index.js & client.js）
- `npm pack --dry-run` 确认 tarball 包含 `lib/`、`src/`、`tsconfig.json`、`client.js`、`cordis.patch.yml`
- `plugin_check` 复验：issue 所列 fail/warning **全部消除**（剩余 `invalid-name` 为组织命名政策项，不在本 issue 报告范围，属仓库既有 `@omdsh-dev` 命名决策）
