### PR TITLE
fix: only bare Enter assembles the annotation block (Ctrl/Shift/Meta+Enter no longer misfire)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.18] - 2026-08-18
+### 修复
+- **修饰键 + Enter 不再误触发拼稿（issue #10）**：`onKeyDown` 的 composer Enter 拦截只处理裸 Enter——Ctrl/Meta+Enter（官方 accelerated 提交）、Shift+Enter（换行）与浏览器默认换行路径都不会再调用 `attachAndSend`，批注块不再以明文出现进输入框；IME 守卫（isComposing / keyCode 229 / compositionend latch）保持不变。
+
 ## [1.3.17] - 2026-08-18
 ### 兼容性
 - **dsh 0.1.0-rc.7 适配核查（无需代码改动）**：Node half 为零依赖空实现、`client.js` 自包含，不依赖任何 `@deepseek-ai/*` 运行时包；`dsh.client.inject` 依赖的 `@deepseek-ai/dsh-client-runtime` / `@deepseek-ai/dsh-client-ui-conversation` 在 rc.7 契约不变；rc.7 conversation 新增 Safari textarea 修复不影响本插件依赖的 `data-composer-card` / `data-streaming` / `data-chat-flow` / `data-chat-anchor-key` / `data-time-hover-root` / `data-turn-tail` / `data-input-scroll` 等选择器；`npm run check` 通过，rc.7 全量 web 演练及线上健康检查通过。

--- a/client.js
+++ b/client.js
@@ -876,7 +876,10 @@ window.__ModuleLoader__.load({
         // 批注清单 + 用户输入的问题。用户始终看不到文本被塞进去。
         // IME 铁律（v1.3.10 修了 nativeEvent.keyCode；v1.3.11 补 compositionend
         // 后 Enter keyCode=13 的时序洞）：合成期 / 上屏确认 Enter 绝不能 setDraft。
-        if (e.key === 'Enter' && ui.quotes.length > 0 && !isImeKeyBlocked(e)) {
+        // 修饰键守卫（v1.3.18）：只拦裸 Enter——Shift+Enter 换行、Ctrl/Meta+Enter
+        // 官方 accelerated 提交、以及浏览器默认换行路径都不应触发拼稿。
+        if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
+          && ui.quotes.length > 0 && !isImeKeyBlocked(e)) {
           var ta = e.target
           if (ta instanceof HTMLTextAreaElement && ta.closest && ta.closest('[data-composer-card]') !== null) {
             attachAndSend()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omdsh-dev/dsh-annotation",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "type": "module",
   "description": "DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the annotation block with your message — the model replies to each annotation by number, with hoverable chips in the reply.",
   "main": "lib/index.js",


### PR DESCRIPTION
## Problem
Issue #10: pressing **Ctrl+Enter** (or Shift/Cmd+Enter) in the composer while annotations were collected called `attachAndSend()` and dumped the raw annotation block into the draft via `setDraft`. Only IME composition was guarded — modifier-key Enter paths (newline, accelerated submit) were not.

## Fix
`client.js` `onKeyDown` now only intercepts a **bare Enter**:

```js
if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
  && ui.quotes.length > 0 && !isImeKeyBlocked(e)) {
```

- Shift+Enter keeps its newline behavior
- Ctrl/Meta+Enter keeps the official accelerated-submit path
- Browser-default newline paths are no longer hijacked
- IME guards (`isComposing` / `keyCode 229` / compositionend latch) unchanged

## Test
- `node --check client.js` passes
- Live smoke: Ctrl+Enter and Shift+Enter in the composer no longer insert the block text; plain Enter still assembles + sends

Fixes #10