### PR TITLE
docs: cross-platform restart instructions (macOS / WSL-Linux / no service manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ dsh plugin --profile web add git+https://github.com/omdsh-dev/dsh-annotation.git
 # local path install (development / debugging)
 cd /path/to/dsh-annotation
 dsh plugin --profile web add .
-# restart the web service
-launchctl kickstart -k "gui/$(id -u)/com.dsh.web"
+# restart the web service — see "Restarting the web service" below
 ```
 
 | Do | Don't |
@@ -72,6 +71,22 @@ Self-check:
 dsh --profile web --dump-config | rg "id: dsh-annotation"   # must be exactly 1 line
 curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-dev/dsh-annotation/client.js"   # 200
 ```
+
+## Restarting the web service
+
+Pick the command for your platform:
+
+```sh
+# macOS (launchd)
+launchctl kickstart -k "gui/$(id -u)/com.dsh.web"
+
+# WSL / Linux with systemd user services
+# The unit name may differ by install method; check with:
+#   systemctl --user list-units | rg dsh
+systemctl --user restart dsh-web
+```
+
+Environments without a service manager (e.g. some containers) often need **no restart at all**: `client.js` is served per request with no caching, so a hard refresh (Cmd/Ctrl+Shift+R) picks up plugin changes. The self-check commands above are platform-neutral.
 
 ## Architecture notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,8 +58,7 @@ dsh plugin --profile web add git+https://github.com/omdsh-dev/dsh-annotation.git
 # 本地路径安装（开发调试）
 cd /path/to/dsh-annotation
 dsh plugin --profile web add .
-# 重启 web
-launchctl kickstart -k "gui/$(id -u)/com.dsh.web"
+# 重启 web —— 见下方「重启 web 服务」
 ```
 
 | 做 | 不做 |
@@ -72,6 +71,22 @@ launchctl kickstart -k "gui/$(id -u)/com.dsh.web"
 dsh --profile web --dump-config | rg "id: dsh-annotation"   # 必须恰好 1 行
 curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-dev/dsh-annotation/client.js"   # 200
 ```
+
+## 重启 web 服务
+
+按平台选择对应命令：
+
+```sh
+# macOS（launchd）
+launchctl kickstart -k "gui/$(id -u)/com.dsh.web"
+
+# WSL / Linux（systemd 用户服务）
+# 服务名可能因安装方式而异，可用以下命令确认：
+#   systemctl --user list-units | rg dsh
+systemctl --user restart dsh-web
+```
+
+没有服务管理器的环境（如部分容器）通常**不需要重启**：`client.js` 按请求读取、no-cache，硬刷新（Cmd/Ctrl+Shift+R）即可加载插件改动。上面的自检命令跨平台通用。
 
 ## 架构要点
 


### PR DESCRIPTION
## Problem
Issue #12: the install snippet's restart command was macOS-only (`launchctl kickstart -k ...`), which is wrong for WSL/Linux (systemd user service) and unnecessary in environments without a service manager.

## Changes
Both `README.md` and `README.zh-CN.md`:

- Replace the hard-coded `launchctl` line in the install snippet with a pointer to a new section
- Add a **“Restarting the web service” / 「重启 web 服务」** section:
  - **macOS**: `launchctl kickstart -k "gui/$(id -u)/com.dsh.web"`
  - **WSL / Linux (systemd user services)**: `systemctl --user restart dsh-web`, with a note that the unit name may differ and how to check it
  - **No service manager (some containers)**: no restart needed — `client.js` is served no-cache per request, so a hard refresh is enough; the self-check commands are platform-neutral

Fixes #12
