### PR TITLE
docs: 确认适配 DSH 0.1.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### 兼容性
+- **dsh 0.1.0-rc.8**：确认浏览器模块加载、会话作用域、输入提交、语言切换及批注依赖的页面锚点均保持兼容；无需增加兼容层，`npm run check` 全通过。
+
 ## [1.4.1] - 2026-08-18
 ### 修复
 - **恢复 Cmd/Ctrl+Enter 纯批注直接发送（issue #17）**：v1.3.18 为修 issue #10 把修饰键 Enter 全部排除，导致空草稿时 Cmd/Ctrl+Enter 无法直接发送纯批注。现仅在草稿为空时接管 Cmd/Ctrl+Enter，并在 capture 阶段主动 `submit('queue')`，避免 composer 的 accelerated 路径在「运行中 + 有排队消息」时误走 steerQueue 而把批注块留在输入框；草稿已有文字时仍交由 composer 处理，保留宿主的 Queue / Steer 策略。


### PR DESCRIPTION
## 结论
Annotation 在 DSH rc.8 下无需兼容层：浏览器模块加载、会话作用域、输入提交、语言切换及页面锚点契约均保持兼容。

## 验证
- npm run check 通过
- 1 项快捷键回归测试通过
- 本机 DSH rc.8 真实页面已完成 Annotation 加载与注入