### PR TITLE
Publish package under personal npm scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### 发布
+- npm 发布作用域改为个人账号 `@changfenhuang/dsh-annotation`；GitHub 仓库继续保留在 `omdsh-dev` 组织。同步更新运行时模块标识、资源路由和安装文档，不保留旧 npm 名称兼容层。
+
 ### 修复
 - **斜杠命令不再被批注拼稿降级（issue #20）**：有待发送批注时输入 `/goal` 等命令并回车，v1.4.1 会把批注块前置进草稿，破坏 DSH 输入机的命令 token 前缀（watchClaim 释放声明），命令被降级为普通消息发出、goal 无法启用。现在命令草稿原样放行、不拼批注，批注保留并随下一条普通消息附带，同时弹 toast 提示（zh/en）。
 ### 兼容性

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Select assistant text ──▶ Toolbar "Annotate" ──▶ Write note / save e
 ## Install (official bundle path · the only one)
 
 ```sh
-# Public GitHub install (works without an npm account)
+# Public npm package (works without an npm account)
+dsh plugin --profile web add @changfenhuang/dsh-annotation
+# Or install directly from the public GitHub source
 dsh plugin --profile web add git+https://github.com/omdsh-dev/dsh-annotation.git
 # local path install (development / debugging)
 cd /path/to/dsh-annotation
@@ -71,7 +73,7 @@ Self-check:
 
 ```sh
 dsh --profile web --dump-config | rg "id: dsh-annotation"   # must be exactly 1 line
-curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-dev/dsh-annotation/client.js"   # 200
+curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@changfenhuang/dsh-annotation/client.js"   # 200
 ```
 
 ## Restarting the web service

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,9 @@
 ## 安装（官方 bundle 路径 · 唯一）
 
 ```sh
-# GitHub 公开仓库安装（无需 npm 账号）
+# npm 公开包安装（无需 npm 账号）
+dsh plugin --profile web add @changfenhuang/dsh-annotation
+# 也可以直接从 GitHub 公开源码安装
 dsh plugin --profile web add git+https://github.com/omdsh-dev/dsh-annotation.git
 # 本地路径安装（开发调试）
 cd /path/to/dsh-annotation
@@ -71,7 +73,7 @@ dsh plugin --profile web add .
 
 ```sh
 dsh --profile web --dump-config | rg "id: dsh-annotation"   # 必须恰好 1 行
-curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@omdsh-dev/dsh-annotation/client.js"   # 200
+curl -s -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:3080/plugins/@changfenhuang/dsh-annotation/client.js"   # 200
 ```
 
 ## 重启 web 服务

--- a/client.js
+++ b/client.js
@@ -40,8 +40,8 @@
 // 同时覆盖两种视图结构（见 assistantRows / allMessageRows / assistantRowOf）。
 window.__ModuleLoader__.load({
   // 必须与 package.json "name" 完全一致，否则 client-modules 报：
-  // bundle loaded without registering "@omdsh-dev/dsh-annotation"
-  id: '@omdsh-dev/dsh-annotation',
+  // bundle loaded without registering "@changfenhuang/dsh-annotation"
+  id: '@changfenhuang/dsh-annotation',
   factory: (require) => {
     'use strict'
     var module = { exports: {} }
@@ -2041,7 +2041,7 @@ window.__ModuleLoader__.load({
       }
     }
 
-    exports.name = '@omdsh-dev/dsh-annotation'
+    exports.name = '@changfenhuang/dsh-annotation'
     exports.inject = ['sessions', 'conversation', 'locale']
     exports.apply = apply
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,3 +1,3 @@
 - insert:
     - id: dsh-annotation
-      name: '@omdsh-dev/dsh-annotation'
+      name: '@changfenhuang/dsh-annotation'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@omdsh-dev/dsh-annotation",
+  "name": "@changfenhuang/dsh-annotation",
   "version": "1.4.1",
   "type": "module",
   "description": "DSH Web selection-annotation plugin: select assistant text, annotate (optional), and press Enter to send the annotation block with your message — the model replies to each annotation by number, with hoverable chips in the reply.",


### PR DESCRIPTION
## Summary
- publish as `@changfenhuang/dsh-annotation`
- keep the GitHub repository in `omdsh-dev`
- update runtime identity and installation docs

## Verification
- `npm run check`: 5 passed, 0 failed
- `npm pack --dry-run` passed