### PR TITLE
docs: add migration steps for pre-rename installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ npm install @changfenhuang/dsh-annotation
 
 > `npm install` only adds the dependency; it does not register the plugin with DSH. Use `dsh plugin add` above when installing it into DSH.
 
+### Migrating from the old `@omdsh-dev` package name
+
+If you installed the plugin before v1.4.2, remove the old dependency before installing the renamed package:
+
+```sh
+dsh plugin --profile web remove @omdsh-dev/dsh-annotation
+dsh plugin --profile web add @changfenhuang/dsh-annotation
+```
+
+If `dsh web` still fails and mentions `@omdsh-dev/dsh-annotation`, remove only the stale `dsh-annotation` entry that uses that old name from `~/.dsh/profiles/web/cordis.patch.yml`. The plugin now supplies the `@changfenhuang/dsh-annotation` entry itself.
+
 | Do | Don't |
 |----|------|
 | Only `dsh plugin add` / only write `bundles` | **Never** insert the same id again in the profile/home `cordis.patch.yml` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,6 +73,17 @@ npm install @changfenhuang/dsh-annotation
 
 > `npm install` 只添加依赖，不会把插件注册到 DSH；在 DSH 中使用时仍应执行上面的 `dsh plugin add`。
 
+### 从旧 `@omdsh-dev` 包名迁移
+
+如果你在 v1.4.2 之前安装过插件，请先删除旧依赖，再安装改名后的包：
+
+```sh
+dsh plugin --profile web remove @omdsh-dev/dsh-annotation
+dsh plugin --profile web add @changfenhuang/dsh-annotation
+```
+
+如果 `dsh web` 仍然启动失败并提到 `@omdsh-dev/dsh-annotation`，请只删除 `~/.dsh/profiles/web/cordis.patch.yml` 中使用该旧名字的 `dsh-annotation` 登记。插件现在会自行提供 `@changfenhuang/dsh-annotation` 登记。
+
 | 做 | 不做 |
 |----|------|
 | 只 `dsh plugin add` / 只写 `bundles` | **不要**再在 profile/home `cordis.patch.yml` insert 同 id |


### PR DESCRIPTION
The annotation package has the same old-profile failure mode as dsh-genui after the @omdsh-dev to @changfenhuang rename. This documents the complete recovery path: remove the stale dependency, install the renamed package, and remove only a leftover old-scope annotation entry from the user overlay when present. The English and Chinese guides stay aligned.

Verification: git diff --check passed, and the public documentation assertions cover all three migration steps. The same package-name migration was verified against the live local DSH profile.