### PR TITLE
perf: 流式期间不再逐 mutation 批次全文档扫描(仅 childList 批次同步, 芯片 500ms 限流)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### 性能
+- **流式期间不再逐 mutation 批次全文档扫描（issue #31）**：decorateAll 原先在 body 全树 MutationObserver（childList: subtree: characterData: attributes:）的每个相关批次上同步执行——流式输出期的主体批次是 attributes/characterData（实测 20s 内 245 批次、0 个 childList），每次都是 querySelectorAll('[data-chat-flow-kind]') + 每行子树查询 + textContent，成本随会话长度线性增长。现在只有含 childList（消息行插入）的批次才同步执行完整装饰（保证「隐藏批注块」先于绘制，无闪烁回归）；流式批次改为 500ms 限流的助手芯片增量扫描（行内 data-streaming 守卫不变，芯片替换时序不变）；1s 兜底轮询保留。实测 20s 流式窗口 CPU 采样中 querySelectorAll 命中从 ~100 降至 17，decorateAll 不再出现在热路径；长会话（500+ 行）预期每帧节省 1-4ms 主线程。
 
 ## [1.4.2] - 2026-08-24
 ### 文档

--- a/client.js
+++ b/client.js
@@ -1066,10 +1066,25 @@ window.__ModuleLoader__.load({
       var observer = new MutationObserver(function (mutations) {
         if (!mutationRelevant(mutations)) return
         onLayoutChange()
-        // 消息行插入/内容填充的瞬间同步执行气泡装饰（隐藏批注块 + 贴标签）：
+        // 只有「消息行插入」批次才同步执行气泡装饰（隐藏批注块 + 贴标签）：
         // MutationObserver 回调在微任务阶段运行，早于浏览器绘制，
         // 用户看不到「先显示批注块再隐藏」的闪烁。
-        decorateAll()
+        // 流式输出期的主体 mutation 是 attributes/characterData（每个 token 帧一层
+        // class/style/文本变更，实测 20s 内 245 批次 0 个 childList）：行插入本来
+        // 就携带完整批注块，逐一触发全文档扫描（decorateAll 是 querySelectorAll +
+        // 每行子树查询 + textContent，成本随会话长度线性增长）会在长会话上白白
+        // 烧主线程；漏网场景由下方 1s 兜底轮询覆盖。
+        var hasRowInsert = false
+        for (var i = 0; i < mutations.length; i++) {
+          if (mutations[i].type === 'childList') { hasRowInsert = true; break }
+        }
+        if (hasRowInsert) {
+          decorateAll()
+          return
+        }
+        // 流式批次: 只做助手回复芯片的限流装饰(行内 data-streaming 守卫已保证
+        // 流式中不做替换, 结束后的首拍芯片滞后 ≤500ms), 不再逐批全文档扫描。
+        scheduleAssistantDecorate()
       })
       observer.observe(document.body, { childList: true, subtree: true, characterData: true, attributes: true })
 
@@ -1885,6 +1900,25 @@ window.__ModuleLoader__.load({
       }
 
       /** 扫描所有已结束流式输出的助手行：把「Annotation N：」替换为可悬浮芯片。 */
+      /** 流式 mutation 批次的芯片装饰限流: 前导 + 500ms 拖尾, 每批次最多触发一次
+       *  增量扫描(只扫助手行), 代替逐批全文档 decorateAll。 */
+      var lastAssistantDecorate = 0
+      var assistantDecorateTimer = null
+      function scheduleAssistantDecorate() {
+        var now = performance.now()
+        if (now - lastAssistantDecorate >= 500) {
+          lastAssistantDecorate = now
+          decorateAssistantAnnotations()
+          return
+        }
+        if (assistantDecorateTimer !== null) return
+        assistantDecorateTimer = setTimeout(function () {
+          assistantDecorateTimer = null
+          lastAssistantDecorate = performance.now()
+          decorateAssistantAnnotations()
+        }, 500 - (now - lastAssistantDecorate))
+      }
+
       function decorateAssistantAnnotations() {
         var rows = assistantRows()
         for (var i = 0; i < rows.length; i++) {


### PR DESCRIPTION
## 摘要

流式输出期间不再逐 mutation 批次全文档扫描。修复针对 issue #31：body 全树 MutationObserver（childList+subtree+characterData+attributes）的每个相关批次都会同步执行 `decorateAll` —— 实测流式 20s 内 245 个批次、其中 **0 个 childList**（224 attributes + 21 characterData），也就是每帧都在跑全文档 `querySelectorAll + 每行子树查询 + textContent`，成本随会话长度线性增长。

## 改动

`client.js` 两处：

1. **观察器回调**（~L1066）：只有含 childList（消息行插入）的批次才同步执行完整 `decorateAll`——「用户气泡插入时就携带完整批注块」，隐藏批注块仍先于绘制（microtask → 无闪烁回归）；attributes/characterData 批次（流式噪音）改为调度限流芯片装饰。
2. **新增 `scheduleAssistantDecorate()`**：前导 + 500ms 拖尾的限流扫描，只跑 `decorateAssistantAnnotations()`（只扫助手行，且行内 `data-streaming` 守卫不变——流式中仍不替换，结束后首拍芯片滞后 ≤500ms）。

1s 兜底轮询（`kickDecorate`）保留，覆盖非 childList 填充等漏网场景。

## 验证

在真实 DSH 0.1.1-rc.2 Web GUI + headless Chrome 电测：

- 补丁版 1.4.0 在真实 profile 加载运行 0 报错（插件模块注册、批注装饰路径、会话渲染均正常）；
- 20s 流式窗口 CPU 采样对比：`querySelectorAll` 命中 **~100 → 17**，`decorateAll`/`decorateAssistantAnnotations` 帧不再出现在热路径（此前每秒 12+ 次）；
- 无行为回归：消息行插入的同步装饰路径保持原样，芯片替换时序由 `data-streaming` 守卫保证，仅限频。

## 后续（不在本 PR）

- `mutationRelevant` 每条记录最多 3 次 `closest()` 祖先链查询，可做记忆化；
- 1Hz 兜底轮询可改为脏标记驱动 + visibilitychange 停表。

#issue 31
