### PR TITLE
fix: 适配新版输入区的回车批注发送

### DIFF
--- a/client.js
+++ b/client.js
@@ -1108,8 +1108,8 @@ window.__ModuleLoader__.load({
         // 纯批注能直接发出，同时不会把批注块明文留在输入框。
         if (e.key === 'Enter' && !e.shiftKey && !e.altKey
           && ui.quotes.length > 0 && !isImeKeyBlocked(e)) {
-          var ta = e.target
-          if (ta instanceof HTMLTextAreaElement && ta.closest && ta.closest('[data-composer-card]') !== null) {
+          var input = e.target instanceof Element && e.target.closest('[data-composer-input]')
+          if (input !== null && input.closest('[data-composer-card]') !== null) {
             var attached = attachAndSend(e)
             if (attached && (e.ctrlKey || e.metaKey)) {
               e.preventDefault()

--- a/test/enter-policy.test.mjs
+++ b/test/enter-policy.test.mjs
@@ -36,6 +36,13 @@ test('attachAndSend 在 setDraft 之前拦截命令草稿', () => {
   assert.ok(guard < splice, 'command guard must run before setDraft splices the block')
 })
 
+test('新版可编辑输入区按 Enter 会进入批注拼稿（issue #41）', () => {
+  const fn = source.match(/function onKeyDown\(e\) \{[\s\S]*?\n      \}/)
+  assert.ok(fn, 'client.js should define onKeyDown')
+  assert.match(fn[0], /closest\('\[data-composer-input\]'\)/)
+  assert.doesNotMatch(fn[0], /HTMLTextAreaElement/)
+})
+
 test('发送按钮在 pointerdown 阶段先拼稿，空草稿按钮则由插件直接提交', () => {
   const fn = source.match(/function onSendPointerDown\(e\) \{[\s\S]*?\n      \}/)
   assert.ok(fn, 'client.js should define onSendPointerDown')


### PR DESCRIPTION
## 发生了什么

DSH 0.1.2-alpha.1 的输入区已从 textarea 改为带 data-composer-input 的可编辑 div，旧守卫因此完全跳过 Enter 拼稿。

## 修复

- Enter 入口改为识别 data-composer-input 及其内部节点
- 保留输入区卡片范围限制
- 补 issue #41 回归检查，防止退回旧 textarea 守卫

## 验证

- npm run check：11/11 通过
- 隔离启动 dsh-v0.1.2-alpha.1，并确认服务实际返回的插件脚本包含新版输入区守卫

关联 issue #41；合并后保持 issue 开放，等待报告者在 Windows / DSH Desktop 2.0.4 复测。