### PR TITLE
fix: 批注工具条默认出现在选区下方（below-first），避开原生选中菜单遮挡

### DIFF
--- a/client.js
+++ b/client.js
@@ -722,8 +722,18 @@ window.__ModuleLoader__.load({
       var w = 400
       var left = rect.left + rect.width / 2 - w / 2
       left = Math.max(8, Math.min(left, window.innerWidth - w - 8))
-      var top = rect.top - height - 8
-      if (top < 8) top = Math.min(rect.bottom + 8, window.innerHeight - height - 8)
+      // 下方优先：原生选中菜单（移动端长按菜单、桌面 Copy/Search 浮层）锚定在选区
+      // 上沿附近，且原生 UI 恒绘制在页面内容之上（z-index 无效），工具条放上方必被
+      // 遮挡；因此下方放得下就放下方，放不下才回上方。
+      var belowTop = rect.bottom + 8
+      var belowFits = belowTop + height <= window.innerHeight - 8
+      var top
+      if (belowFits) {
+        top = belowTop
+      } else {
+        top = rect.top - height - 8
+        if (top < 8) top = Math.min(rect.bottom + 8, window.innerHeight - height - 8)
+      }
       return { left: Math.round(left), top: Math.round(Math.max(8, top)) }
     }
 


### PR DESCRIPTION
## 问题

选中助手消息文字后，批注工具条默认出现在选区**上方**，移动端会被浏览器**原生长按菜单**（复制/搜索/分享浮层）直接盖住：原生菜单锚定在选区上沿附近，且原生 UI 恒绘制在页面内容之上，工具条无论 z-index 多大都无法显示在其上层。桌面端 Edge/Chrome 的原生 Copy/Search 浮层同理。

复现（移动端 100%）：Android 平板（联想 Y700）+ Edge 打开 DSH Web，长按选中助手回复中任意文字 → 工具条出现在选区上方，与原生长按菜单重叠，无法点击。

## 根因

`placeAbove()` 目前上方优先（`top = rect.top - height - 8`，上方放不下才回落下方），而原生选中菜单恰好也锚定选区上沿，两者必然重叠。

## 方案

`placeAbove()` 改为**下方优先**（below-first）：

- `belowTop = rect.bottom + 8`；若 `belowTop + height <= window.innerHeight - 8` 则放下方
- 否则回落上方，保留原有逻辑与底部钳制

坐标系一致性：`rect`（`getBoundingClientRect`，布局视口坐标）与 `window.innerHeight`（布局视口高）同属布局视口坐标系，Android 地址栏伸缩时两者同步变化，判断在任意状态下都一致（未引入 visualViewport）。

## 测试

- Windows 11 桌面 Edge：选中任意文字 → 工具条出现在选区下方 8px；选区贴近视口底部时正确回落上方
- Android 平板（联想 Y700）Edge：长按选字 → 工具条出现在下方，不再被长按菜单遮挡
- 环境：DSH 0.1.2-rc.1 + `@changfenhuang/dsh-annotation` 1.4.8