### PR TITLE
fix: 批注浮层避开输入框，并支持拖动编辑窗口

### DIFF
--- a/client.js
+++ b/client.js
@@ -722,8 +722,18 @@ window.__ModuleLoader__.load({
       var w = 400
       var left = rect.left + rect.width / 2 - w / 2
       left = Math.max(8, Math.min(left, window.innerWidth - w - 8))
-      var top = rect.top - height - 8
-      if (top < 8) top = Math.min(rect.bottom + 8, window.innerHeight - height - 8)
+      // 下方优先：原生选中菜单（移动端长按菜单、桌面 Copy/Search 浮层）锚定在选区
+      // 上沿附近，且原生 UI 恒绘制在页面内容之上（z-index 无效），工具条放上方必被
+      // 遮挡；因此下方放得下就放下方，放不下才回上方。
+      var belowTop = rect.bottom + 8
+      var belowFits = belowTop + height <= window.innerHeight - 8
+      var top
+      if (belowFits) {
+        top = belowTop
+      } else {
+        top = rect.top - height - 8
+        if (top < 8) top = Math.min(rect.bottom + 8, window.innerHeight - height - 8)
+      }
       return { left: Math.round(left), top: Math.round(Math.max(8, top)) }
     }
 

--- a/client.js
+++ b/client.js
@@ -94,7 +94,7 @@ window.__ModuleLoader__.load({
         '  font-family: var(--dsw-font-family, system-ui);',
         '  animation: dsh-ann-pop .12s var(--ds-ease-in-out, ease); }',
         '.dsh-ann-card-head { display: flex; align-items: center; justify-content: space-between;',
-        '  margin-bottom: 8px; }',
+        '  margin-bottom: 8px; cursor: move; touch-action: none; user-select: none; }',
         '.dsh-ann-card-title { font-size: 13px; font-weight: 600;',
         '  color: var(--dsw-alias-label-primary); }',
         '.dsh-ann-quote { font-size: 12px; line-height: 1.55;',
@@ -833,6 +833,7 @@ window.__ModuleLoader__.load({
       document.body.appendChild(host)
       var overlay = document.createElement('div')
       overlay.setAttribute('data-annotation-overlay', '')
+      overlay.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:900;'
       document.body.appendChild(overlay)
 
       var ui = {
@@ -1028,6 +1029,7 @@ window.__ModuleLoader__.load({
           anchorRaf = false
           if (ui.quotes.length > 0) renderMarkers()
           updateChip()
+          if (ui.mode === 'editing' && ui.el !== null) positionEditor(ui.el, ui.pos.left, ui.pos.top)
           if (ui.mode !== 'actions' || ui.quote === '') return
           var rect = null
           var sel = window.getSelection()
@@ -1227,6 +1229,7 @@ window.__ModuleLoader__.load({
           ui.el = card
           var head = document.createElement('div')
           head.className = 'dsh-ann-card-head'
+          makeEditorDraggable(head, card)
           var title = document.createElement('div')
           title.className = 'dsh-ann-card-title'
           title.textContent = ui.editingId !== null ? t('edit.editTitle') : t('edit.addTitle')
@@ -1274,13 +1277,34 @@ window.__ModuleLoader__.load({
           ta.focus()
           ta.setSelectionRange(ta.value.length, ta.value.length)
           requestAnimationFrame(function () {
-            var h = card.offsetHeight
-            var t = parseFloat(card.style.top)
-            if (t + h > window.innerHeight - 8) {
-              card.style.top = Math.max(8, window.innerHeight - h - 8) + 'px'
-            }
+            if (card.isConnected) positionEditor(card, ui.pos.left, ui.pos.top)
           })
         }
+      }
+
+      function positionEditor(card, left, top) {
+        ui.pos = {
+          left: Math.max(8, Math.min(left, window.innerWidth - card.offsetWidth - 8)),
+          top: Math.max(8, Math.min(top, window.innerHeight - card.offsetHeight - 8)),
+        }
+        card.style.left = ui.pos.left + 'px'
+        card.style.top = ui.pos.top + 'px'
+      }
+
+      function makeEditorDraggable(head, card) {
+        var drag = null
+        head.addEventListener('pointerdown', function (e) {
+          if (e.button !== 0 || !e.isPrimary || e.target.closest('button')) return
+          var r = card.getBoundingClientRect()
+          drag = { id: e.pointerId, x: e.clientX - r.left, y: e.clientY - r.top }
+          head.setPointerCapture(e.pointerId)
+          e.preventDefault()
+        })
+        head.addEventListener('pointermove', function (e) {
+          if (drag === null || e.pointerId !== drag.id) return
+          positionEditor(card, e.clientX - drag.x, e.clientY - drag.y)
+        })
+        head.addEventListener('lostpointercapture', function () { drag = null })
       }
 
       // ---------- 批注标记 ----------
@@ -1303,6 +1327,15 @@ window.__ModuleLoader__.load({
       }
 
       function renderMarkers() {
+        // 对整个标记层挖去输入框区域；滚动、尺寸变化时即使原文没动也要刷新。
+        var composer = document.querySelector('[data-composer-card]')
+        var r = composer !== null ? composer.getBoundingClientRect() : null
+        overlay.style.clipPath = r !== null && r.width > 0 && r.height > 0
+          ? 'polygon(evenodd, 0 0, 100% 0, 100% 100%, 0 100%, 0 0, '
+            + r.left + 'px ' + r.top + 'px, ' + r.right + 'px ' + r.top + 'px, '
+            + r.right + 'px ' + r.bottom + 'px, ' + r.left + 'px ' + r.bottom + 'px, '
+            + r.left + 'px ' + r.top + 'px)'
+          : 'none'
         var sig = markersSignature()
         if (sig !== markersSig) {
           markersSig = sig

--- a/scripts/smoke-pending-switch.mjs
+++ b/scripts/smoke-pending-switch.mjs
@@ -8,7 +8,7 @@ import { createServer } from 'node:http'
 
 const HTML = `<!doctype html><html><body>
   <div id="flow"></div>
-  <div data-composer-card id="composer"><textarea id="ta"></textarea></div>
+  <div data-composer-card id="composer"><div id="ta" data-composer-input contenteditable="true"></div></div>
   <script>
     window.__shells = {}
     function makeShell() {

--- a/test/layout-overlay.test.mjs
+++ b/test/layout-overlay.test.mjs
@@ -16,3 +16,12 @@ test('滚动和布局变化会刷新输入框批注胶囊（issue #44）', () =>
   assert.match(source, /new ResizeObserver\(onLayoutChange\)/)
   assert.match(source, /composerObserver\.disconnect\(\)/)
 })
+
+test('工具条优先选区下方，底部空间不足时放在上方（PR #48）', () => {
+  const match = source.match(/function placeAbove\(rect, height\) \{[\s\S]*?\n    \}/)
+  assert.ok(match)
+  const place = Function('window', `return (${match[0]})`)({ innerWidth: 1000, innerHeight: 800 })
+  assert.equal(place({ left: 200, width: 300, top: 300, bottom: 320 }, 40).top, 328)
+  assert.equal(place({ left: 200, width: 300, top: 750, bottom: 770 }, 40).top, 702)
+  assert.ok(place({ left: -100, width: 300, top: 0, bottom: 800 }, 40).top >= 8)
+})

--- a/test/overlay-browser.mjs
+++ b/test/overlay-browser.mjs
@@ -1,0 +1,76 @@
+// Run with PLAYWRIGHT_MODULE pointing to an existing Playwright installation.
+import assert from 'node:assert/strict'
+const { chromium } = await import(process.env.PLAYWRIGHT_MODULE || 'playwright')
+const browser = await chromium.launch({ channel: 'chrome', headless: true })
+try {
+  const page = await browser.newPage({ viewport: { width: 1000, height: 800 } })
+  const errors = []
+  page.on('pageerror', error => errors.push(String(error)))
+  await page.setContent(`<style>body{margin:0} [data-composer-card]{position:fixed;left:200px;top:600px;width:600px;height:150px;background:white}</style>
+    <div data-chat-flow-kind="assistant-step" style="position:absolute;left:250px;top:350px"><p id="quote">这是用来验证批注拖动和高亮遮挡的原文。</p></div>
+    <div data-composer-card><div data-composer-input contenteditable="true">输入内容</div></div>`)
+  await page.evaluate(() => {
+    window.__ModuleLoader__ = { load(entry) { window.api = entry.factory(() => ({})) } }
+  })
+  await page.addScriptTag({ path: new URL('../client.js', import.meta.url).pathname })
+  await page.evaluate(() => {
+    window.dispose = window.api.apply({ sessions: {
+      list: { getSnapshot: () => ({}), subscribe: () => () => {} }, scope: () => undefined,
+    } })
+    const range = document.createRange()
+    range.selectNodeContents(document.querySelector('#quote'))
+    getSelection().removeAllRanges(); getSelection().addRange(range)
+  })
+  await page.locator('.dsh-ann-bar').waitFor()
+  const quote = await page.locator('#quote').boundingBox()
+  const bar = await page.locator('.dsh-ann-bar').boundingBox()
+  assert.ok(bar.y >= quote.y + quote.height, '工具条位于选区下方')
+  await page.locator('.dsh-ann-bar button').click()
+  await page.locator('.dsh-ann-input').fill('拖动后不能丢失的批注')
+  const before = await page.locator('.dsh-ann-card').boundingBox()
+  const head = await page.locator('.dsh-ann-card-title').boundingBox()
+  await page.mouse.move(head.x + 15, head.y + 5)
+  await page.mouse.down()
+  await page.mouse.move(980, 780, { steps: 5 })
+  await page.mouse.up()
+  const after = await page.locator('.dsh-ann-card').boundingBox()
+  assert.ok(after.x !== before.x && after.y !== before.y, '标题栏可以拖动')
+  assert.ok(after.x + after.width <= 993 && after.y + after.height <= 793, '窗口不会拖出屏幕')
+  assert.equal(await page.locator('.dsh-ann-input').inputValue(), '拖动后不能丢失的批注')
+  await page.setViewportSize({ width: 700, height: 650 })
+  await page.waitForTimeout(100)
+  const resized = await page.locator('.dsh-ann-card').boundingBox()
+  assert.ok(resized.x + resized.width <= 693 && resized.y + resized.height <= 643, '缩小窗口仍可操作')
+  await page.locator('.dsh-ann-action').click()
+  await page.locator('.dsh-ann-hl').first().waitFor()
+  // Make the numbered marker straddle the composer: clipped pixels must not intercept input.
+  await page.evaluate(() => {
+    const composer = document.querySelector('[data-composer-card]')
+    composer.style.top = '340px'
+    composer.style.left = '240px'
+    window.dispatchEvent(new Event('resize'))
+  })
+  await page.waitForTimeout(100)
+  assert.ok(await page.evaluate(() => {
+    const layer = document.querySelector('[data-annotation-overlay]')
+    const marker = document.querySelector('.dsh-ann-num')
+    marker.style.left = '260px'; marker.style.top = '350px'
+    const hit = document.elementFromPoint(265, 355)
+    return CSS.supports('clip-path', layer.style.clipPath)
+      && hit.closest('[data-composer-card]') !== null
+  }), '高亮层和编号在输入区域被裁掉，不遮挡输入')
+  await page.evaluate(() => {
+    document.querySelector('[data-composer-card]').style.top = '550px'
+    window.dispatchEvent(new Event('resize'))
+  })
+  await page.waitForTimeout(100)
+  await page.locator('.dsh-ann-num').click()
+  assert.equal(await page.locator('.dsh-ann-input').inputValue(), '拖动后不能丢失的批注')
+  await page.locator('.dsh-ann-card-head button').click()
+  assert.equal(await page.locator('.dsh-ann-card').count(), 0, '关闭按钮不触发拖动')
+  await page.evaluate(() => window.dispose())
+  assert.deepEqual(errors, [])
+  console.log('PASS: 工具条下方定位、标题栏拖动、边界、缩放、保存、裁剪、重新编辑、取消、无页面错误')
+} finally {
+  await browser.close()
+}


### PR DESCRIPTION
批注高亮会覆盖输入框，编辑批注时卡片也无法移开原文。本次让标记层按输入框实时位置裁去重叠区域，并支持通过标题栏拖动编辑卡片；拖动和窗口缩小时限制卡片位置，保留批注内容及保存、取消交互。

关联 #49、#50。另保留 Dawn388887 在 #48 的原始提交，将工具条改为选区下方优先，并补充下方空间不足时的定位检查。#48 可以先独立合并；本请求当前包含该提交，以便验证完整交互。

验证：
- npm run check：构建、语法和 15 项测试通过。
- 新增可重复运行的浏览器检查 test/overlay-browser.mjs：独立无界面 Chrome 验证下方定位、标题栏拖动、屏幕边界、窗口缩小、保存、输入区域裁剪、重新编辑和关闭，页面错误为 0。使用已有 Playwright 安装运行：PLAYWRIGHT_MODULE=/absolute/path/to/playwright/index.mjs node test/overlay-browser.mjs。
- 现有本地跨会话冒烟脚本更新测试输入区后 7/7 通过：恢复、切走、切回、历史消息装饰、Enter 拼稿、发送清空、发送标签。测试页面的输入区结构修正已一并提交。

这些是 macOS 无界面 Chrome、模拟宿主服务的验证，不代表 Windows Desktop 或 Android 原设备验收。问题保持开放，等待原环境复测；未发布新版本。

#31 的每秒装饰扫描仍在：当前还承担延迟渲染内容的补扫。本次没有删除该机制或宣称性能问题已彻底解决。
